### PR TITLE
Update build tools version to 19.0.1 from 19.0.0

### DIFF
--- a/Demos/build.gradle
+++ b/Demos/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 android {
   compileSdkVersion 19
-  buildToolsVersion "19.0.0"
+  buildToolsVersion "19.0.1"
 
   defaultConfig {
     minSdkVersion 18


### PR DESCRIPTION
This fixes ./gradlew installDebug for me
