### PR TITLE
Fixed some broken code

### DIFF
--- a/JavaDocs/com/estimote/sdk/cloud/EstimoteCloud.html
+++ b/JavaDocs/com/estimote/sdk/cloud/EstimoteCloud.html
@@ -110,7 +110,7 @@ extends <a href="http://d.android.com/reference/java/lang/Object.html?is-externa
  Usage:
  <pre>
    EstimoteSDK.initialize(applicationContext, appId, appToken);
-   EstimoteCloud.get().fetchBeaconDetails("AA:BB:CC:AA:BB:CC", callback);
+   EstimoteCloud.getInstance().fetchBeaconDetails("AA:BB:CC:AA:BB:CC", callback);
  </pre></div>
 </li>
 </ul>


### PR DESCRIPTION
The `get()` is not a method - it was a typo originally that was meant to be `.getInstance()`.