### PR TITLE
Updating gradle build tools of demo application to version 1.2.3

### DIFF
--- a/Demos/build.gradle
+++ b/Demos/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
-    classpath 'com.android.tools.build:gradle:1.1.3'
+    classpath 'com.android.tools.build:gradle:1.2.3'
   }
 }
 


### PR DESCRIPTION
In this Pull Request I am updating Gradle plug-in to build Android applications in demo application to the newest version, which is 1.2.3. It was automatically suggested by Android Studio after opening the project.

I hope, it will be helpful for you.