### PR TITLE
setting EXTRAS_TARGET_ACTIVITY value from proper Activity for Sensors Demo

### DIFF
--- a/Demos/src/main/java/com/estimote/examples/demos/activities/AllDemosActivity.java
+++ b/Demos/src/main/java/com/estimote/examples/demos/activities/AllDemosActivity.java
@@ -28,6 +28,7 @@ public class AllDemosActivity extends AppCompatActivity {
         startActivity(intent);
       }
     });
+
     findViewById(R.id.notify_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListBeaconsActivity.class);
@@ -35,6 +36,7 @@ public class AllDemosActivity extends AppCompatActivity {
         startActivity(intent);
       }
     });
+
     findViewById(R.id.characteristics_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListBeaconsActivity.class);
@@ -42,6 +44,7 @@ public class AllDemosActivity extends AppCompatActivity {
         startActivity(intent);
       }
     });
+
     findViewById(R.id.update_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListBeaconsActivity.class);
@@ -49,6 +52,7 @@ public class AllDemosActivity extends AppCompatActivity {
         startActivity(intent);
       }
     });
+
     findViewById(R.id.eddystone_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListEddystoneActivity.class);
@@ -56,6 +60,7 @@ public class AllDemosActivity extends AppCompatActivity {
         startActivity(intent);
       }
     });
+
     findViewById(R.id.nearables_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListNearablesActivity.class);
@@ -67,7 +72,7 @@ public class AllDemosActivity extends AppCompatActivity {
     findViewById(R.id.sensors_demo_button).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         Intent intent = new Intent(AllDemosActivity.this, ListBeaconsActivity.class);
-        intent.putExtra(ListNearablesActivity.EXTRAS_TARGET_ACTIVITY, SensorsActivity.class.getName());
+        intent.putExtra(ListBeaconsActivity.EXTRAS_TARGET_ACTIVITY, SensorsActivity.class.getName());
         startActivity(intent);
       }
     });


### PR DESCRIPTION
I see that for Sensors Demo we're starting `ListBeaconsActivity`, but we're using `EXTRAS_TARGET_ACTIVITY` value from `ListNearablesActivity`. I think, we should use `EXTRAS_TARGET_ACTIVITY` from `ListBeaconsActivity` in this case. It's working properly, because values from these two different activities are the same. It could stop working correctly when someone changes `EXTRAS_TARGET_ACTIVITY` value in `ListNearablesActivity`.