### PR TITLE
fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Apps can use the `startRanging` method of the `BeaconManager` class to determine
 
 ### Monitoring
 
-Apps can use the `startMonitoring` method of the `BeaconManager` class to start monitoring regions. Monitoring updates come to listeners registered with the `setMonitoringListener` method of the `BeaconsManager` class.
+Apps can use the `startMonitoring` method of the `BeaconManager` class to start monitoring regions. Monitoring updates come to listeners registered with the `setMonitoringListener` method of the `BeaconManager` class.
 
 Monitoring is designed to perform periodic scans in the background. By default it scans for 5 seconds and sleeps for 25 seconds. This means that it can take by default up to 30 seconds to detect entering or exiting a region. Default behaviour can be changed via `BeaconManager#setBackgroundScanPeriod`.
 


### PR DESCRIPTION
Hi,

I've found small typo in `README.md`.
In this PR, I've changed `BeaconsManager` to `BeaconManager`.

Regards,
Piotr